### PR TITLE
updated audited table columns to support uuid

### DIFF
--- a/db/migrate/20200510034140_fix_audited.rb
+++ b/db/migrate/20200510034140_fix_audited.rb
@@ -1,0 +1,28 @@
+class FixAudited < ActiveRecord::Migration[6.0]
+  def change
+    drop_table :audits
+
+    create_table :audits, :force => true do |t|
+      t.column :auditable_id, :uuid
+      t.column :auditable_type, :string
+      t.column :associated_id, :uuid
+      t.column :associated_type, :string
+      t.column :user_id, :uuid
+      t.column :user_type, :string
+      t.column :username, :string
+      t.column :action, :string
+      t.column :audited_changes, :jsonb
+      t.column :version, :integer, :default => 0
+      t.column :comment, :string
+      t.column :remote_address, :string
+      t.column :request_uuid, :string
+      t.column :created_at, :datetime
+    end
+
+    add_index :audits, [:auditable_type, :auditable_id, :version], :name => 'auditable_index'
+    add_index :audits, [:associated_type, :associated_id], :name => 'associated_index'
+    add_index :audits, [:user_id, :user_type], :name => 'user_index'
+    add_index :audits, :request_uuid
+    add_index :audits, :created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_02_012248) do
+ActiveRecord::Schema.define(version: 2020_05_10_034140) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -56,9 +56,9 @@ ActiveRecord::Schema.define(version: 2020_05_02_012248) do
   end
 
   create_table "audits", force: :cascade do |t|
-    t.integer "auditable_id"
+    t.uuid "auditable_id"
     t.string "auditable_type"
-    t.integer "associated_id"
+    t.uuid "associated_id"
     t.string "associated_type"
     t.uuid "user_id"
     t.string "user_type"


### PR DESCRIPTION
**This will require a migration in production AND a loss of previous audit history**

Audits table needs migration to change associated record fields to support UUID. Fortunately, the only existing audited model is PIREP status changes which will be lost, however the earlier this fix the better.

