### PR TITLE
Resolves #50 added group_id to permitted parameters

### DIFF
--- a/app/policies/pilot_policy.rb
+++ b/app/policies/pilot_policy.rb
@@ -37,6 +37,6 @@ class PilotPolicy < ApplicationPolicy
     return unless @user.can?(Pilot, :update)
 
     %i[pid active first_name last_name email password
-       password_confirmation time_zone]
+       password_confirmation time_zone group_id]
   end
 end

--- a/app/views/admin/pilots/_form.html.haml
+++ b/app/views/admin/pilots/_form.html.haml
@@ -35,7 +35,7 @@
 
   .form-row
     .col
-      = f.association :group, label: 'Group', hint: 'Permissions the user is granted'
+      = f.association :group, label: 'Group', hint: 'Permissions the user is granted', include_blank: false
 
   .form-row
     .col

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -46,7 +46,7 @@ ActiveRecord::Schema.define(version: 2020_05_16_140121) do
 
   create_table "airports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "icao", limit: 4, null: false
-    t.string "iata", limit: 4
+    t.string "iata", limit: 3
     t.string "name"
     t.string "city"
     t.string "time_zone", default: "UTC", null: false


### PR DESCRIPTION
This pull request corrects a bug referenced in Issue #50 that involved the parameter `group_id` missing from the permitted parameter list in [pilot_policy.rb](/app/policies/pilot_policy.rb)

This was preventing an administrator from managing the Pilot's group assignment.

Additionally corrected the form select on the pilot administration form that included blank as an option. While validation would not allow blank, leaving it as a selectable option creates additional unnecessary ambiguity.
