### PR TITLE
Resolves #61 the recaptcha minimum score should always be a float

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -42,7 +42,8 @@ class ContactsController < ApplicationController
       action: 'contact',
       model: @contact,
       attribute: :recaptcha,
-      minimum_score: Setting.recaptcha_min_score,
+      # FIXME: remove following rails_settings_cached supports float casting
+      minimum_score: Setting.recaptcha_min_score.to_f,
       secret_key: GoogleRecaptcha::SECRET_KEY
     )
 

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -23,7 +23,8 @@ class RegistrationsController < Devise::RegistrationsController
       action: 'registration',
       model: resource,
       attribute: :recaptcha,
-      minimum_score: Setting.recaptcha_min_score,
+      # FIXME: remove following rails_settings_cached supports float casting
+      minimum_score: Setting.recaptcha_min_score.to_f,
       secret_key: GoogleRecaptcha::SECRET_KEY
     )
 


### PR DESCRIPTION
The ```rails_settings_cached``` gem does not currently support typecasting retrieved values to a Float. This causes an issue where ```Settings.recaptcha_min_score``` returns a string.

The Google Recaptcha gem ```recaptcha``` requires a float to compare the minimum allowed score. 

We will need to typecast this ourselves until the ```rails_settings_cached``` gem can support decimal values.