### PR TITLE
Added support for Heroku deployments

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,3 @@
+release: ./bin/docker-entrypoint.sh
+web: bundle exec rails server -p $PORT
+worker: bundle exec sidekiq

--- a/README.md
+++ b/README.md
@@ -99,15 +99,13 @@ smtp:
 
 ### Environment Variables
 
-| Syntax                |             | Description                                         |
-| :---                  |   :----:    | :-----------                                        |
-| RAILS_HOSTNAME        |**required** | External hostname for application                   |
-| RAILS_MASTER_KEY      |**required** | Master key used for credential store                |
-| POSTGRES_HOST         |**required** | Hostname for your PostgreSQL server                 |    
-| POSTGRES_DB           |**required** | Database name ex. skyOS_production                  |
-| POSTGRES_USER         |**required** | Database username                                   |
-| POSTGRES_PASSWORD     |**required** | Database password                                   |
-| SKY_OS_REPLY_TO       |**required** | From address used for default mailer correspondence |
+| Syntax                |             | Description                                               |
+| :---                  |   :----:    | :-----------                                              |
+| DATABASE_URL          |**required** | Database URL see [docker-compose.yml](docker-compose.yml) |
+| RAILS_HOSTNAME        |**required** | External hostname for application                         |
+| RAILS_MASTER_KEY      |**required** | Master key used for credential store                      |
+| REDIS_URL             |**required** | Redis URL see [docker-compose.yml](docker-compose.yml)    |
+| SKY_OS_REPLY_TO       |**required** | From address used for default mailer correspondence       |
 
 ### Rails Settings
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -16,5 +16,4 @@ test:
   database: <%= ENV['POSTGRES_TEST_DB'] %>
 
 production:
-  <<: *default
-  database: <%= ENV['POSTGRES_DB'] %>
+  url: <%= ENV['DATABASE_URL'] %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,10 +32,7 @@ services:
   app:
     build: .
     environment:
-      POSTGRES_DB: skyOS_production
-      POSTGRES_USER: test
-      POSTGRES_PASSWORD: test
-      POSTGRES_HOST: db
+      DATABASE_URL: postgres://test:test@db:5432/skyOS_production
       RAILS_HOSTNAME: demo.lonestar-virtual.org
       RAILS_LOG_TO_STDOUT: 1
       # RAILS_MASTER_KEY: blahblahblah
@@ -57,10 +54,7 @@ services:
     build: .
     command: bundle exec sidekiq
     environment:
-      POSTGRES_DB: skyOS_production
-      POSTGRES_USER: test
-      POSTGRES_PASSWORD: test
-      POSTGRES_HOST: db
+      DATABASE_URL: postgres://test:test@db:5432/skyOS_production
       RAILS_HOSTNAME: demo.lonestar-virtual.org
       RAILS_LOG_TO_STDOUT: 1
       # RAILS_MASTER_KEY: blahblahblah

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -32,10 +32,7 @@ services:
   app:
     image: docker.pkg.github.com/lonestarvirtual/skyos/skyos:latest
     environment:
-      POSTGRES_DB: skyOS_production
-      POSTGRES_USER: skyOS
-      POSTGRES_PASSWORD: super_secret_password
-      POSTGRES_HOST: db
+      DATABASE_URL: postgres://skyOS:super_secret_password@db:5432/skyOS_production
       RAILS_HOSTNAME: my_va_url.org
       RAILS_LOG_TO_STDOUT: 1
       RAILS_MASTER_KEY: super_secret_rails_master_key_here
@@ -55,10 +52,7 @@ services:
     image: docker.pkg.github.com/lonestarvirtual/skyos/skyos:latest
     command: bundle exec sidekiq
     environment:
-      POSTGRES_DB: skyOS_production
-      POSTGRES_USER: skyOS
-      POSTGRES_PASSWORD: super_secret_password
-      POSTGRES_HOST: db
+      DATABASE_URL: postgres://skyOS:super_secret_password@db:5432/skyOS_production
       RAILS_HOSTNAME: my_va_url.org
       RAILS_LOG_TO_STDOUT: 1
       RAILS_MASTER_KEY: super_secret_rails_master_key_here


### PR DESCRIPTION
This PR adds support for simple deployments in Heroku. 

### Justification

Heroku is a common deployment platform for Rails applications. Adding a Procfile and adjusting some of the production required environment variables allows for this application to be deployed easily into Heroku.