### PR TITLE
resolved missing database driver in Production

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -16,4 +16,7 @@ test:
   database: <%= ENV['POSTGRES_TEST_DB'] %>
 
 production:
+  adapter: postgresql
+  encoding: unicode
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   url: <%= ENV['DATABASE_URL'] %>


### PR DESCRIPTION
The change to DATABASE_URL for database configuration caused the adapter, encoding and pool configuration to be missing in production environments.