### PR TITLE
Docker workflow updates

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,6 +18,7 @@ jobs:
 
   publish:
     if: github.event_name == 'push'
+    needs: build
     runs-on: ubunut-latest
     steps:
       - name: 'Publish to GitHub Registry (tag: experimental)'

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,5 +13,26 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         
-      - name: Build the Docker image
+      - name: Build Docker image
         run: docker build . --file Dockerfile
+
+  publish:
+    if: github.event_name == 'push'
+    runs-on: ubunut-latest
+    steps:
+      - name: 'Publish to GitHub Registry (tag: experimental)'
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: lonestarvirtual/skyos/skyos
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.pkg.github.com
+          tags: experimental
+
+      - name: 'Publish Docker Hub (tag: experimental)'
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: lonestarvirtual/skyos
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          tags: experimental

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,3 +24,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: docker.pkg.github.com
           tags: "latest,${{ env.RELEASE_VERSION }}"
+
+      - name: Publish to Docker Registry
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: lonestarvirtual/skyos
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          tags: "latest,${{ env.RELEASE_VERSION }}"


### PR DESCRIPTION
This change updates the GitHub workflow to publish Docker containers to both GitHub and Docker Hub registries.

Additionally, experimental images are published on new merges into the master branch.

### Justification
Publishing to Docker Hub is advantageous for any open source project as it is the agnostic hub for all types of Docker capable projects. Public Docker Hub registries provide access to all users requiring no authentication.

Experimental images in addition to the normal release cycle allow easier testing and faster updates to potential staging environments.