### PR TITLE
Documentation update and Heroku one-click deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,120 @@
-# SkyOS
+# skyOS
 
 ![Verify](https://github.com/lonestarvirtual/skyOS/workflows/Verify/badge.svg)
 [![Maintainability](https://api.codeclimate.com/v1/badges/5d90db83c1ed525e2beb/maintainability)](https://codeclimate.com/github/lonestarvirtual/skyOS/maintainability)
 [![codecov](https://codecov.io/gh/lonestarvirtual/skyOS/branch/master/graph/badge.svg)](https://codecov.io/gh/lonestarvirtual/skyOS)
 
-skyOS is a web-based virtual airline management system written in Rails and 
-used by [Lonestar Cargo](https://lonestarcargo.org). 
+skyOS is a [virtual airline](https://en.wikipedia.org/wiki/Virtual_airline_(hobby))
+management system written in Rails
 
-It is an open-source project that may be used by anyone running a [Virtual 
-Airline](https://en.wikipedia.org/wiki/Virtual_airline_(hobby)). We 
-encourage forks and pull-requests for new features and fixes!
+## Table of Contents
+* [Installation](#installation)
+  * [Docker](#docker)
+  * [Heroku](#heroku)
+  * [Stand-alone](#stand-alone)
+* [Configuration](#configuration)
+* [Contributing](#contributing)
 
-## Development Getting Started
+## Installation
+skyOS is easily deployed as Docker container, a Heroku app, or a 
+stand-alone application behind a custom environment.
 
-Developed with Ruby: 2.6.3 / Rails: 6
+### Docker
+Several pre-built image options are available in addition to building a
+custom image. 
 
+#### Available tags
+* `latest` - Latest released version
+* `experimental` - Created on merge to master (pre-release)
+* [releases](https://github.com/lonestarvirtual/skyOS/releases) - 
+Git tagged version name: `v#.#`
+
+#### Using Compose (recommended)
+See [docker-compose.yml.example](docker-compose.yml.example) for an example on
+how to use this project with Docker Compose.
+
+When using a registry image, only the `docker-compose.yml` file is necessary.
+Customize as necessary and `docker-compose up -d`
+
+#### Building your own image
+Clone the repository and build the Docker image using the included Dockerfile:
+```
+% docker-compose build
+```
+
+### Heroku
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
+One-click installation is available via the Deploy button above. For demo 
+purposes, free resources are selected. Production customization will 
+be necessary.
+
+See [Configuration](#configuration) for details on `Config Vars` 
+environment variables. The `DATABASE_URL` and `REDIS_URL` are automatically
+configured utilizing the add-on mounting in [app.json](app.json)
+
+After the deployment is complete the default administrative credentials are:
+  * Username: `admin@example.com`
+  * Password: `password`
+  
+### Stand-alone
+
+Requirements:
+* Ruby >=2.6.3
+* PostgreSQL >= 10
+* Redis
+* [ImageMagick](https://imagemagick.org/)
+
+## Configuration
+All start-up dependent configuration is managed via environment variables. Any
+configuration that can be changed during run-time is managed through the web
+interface.
+
+### Environment variables
+| Name                  |             | Description                                                               |
+| :---                  |   :----:    | :-----------                                                              |
+| DATABASE_URL          |**required** | Database URL see [docker-compose.yml.example](docker-compose.yml.example) |
+| RAILS_HOSTNAME        |**required** | External hostname for application                                         |
+| REDIS_URL             |**required** | Redis URL see [docker-compose.yml.example](docker-compose.yml.example)    |
+| SECRET_KEY_BASE       |**required** | Key used to sign messages and encrypt cookies                             |
+| SMTP_SERVER           |**required** | Mail server, example: `smtp.example.com`                                  |
+| SMTP_PORT             | *optional*  | Mail server port, default: `25`                                           |
+| SMTP_DOMAIN           | *optional*  | Defaults to `RAILS_HOSTNAME`                                              |
+| SMTP_USERNAME         |**required** | Mail service username                                                     |
+| SMTP_PASSWORD         |**required** | Mail service password                                                     |
+| SMTP_AUTH             | *optional*  | Defaults to `plain`        
+
+### Rake utilities
+Load defaults and create an initial administrative user:
+```
+# Local console
+% rake skyos:install
+
+# On Docker host
+% docker-compose run --rm app rake skyos:install
+```
+
+*Alternatively* only create an administrative user:
+```
+# Local console
+% rake skyos:create_admin
+
+# On Docker host
+% docker-compose run --rm app rake skyos:create_admin
+```
+
+*Optionally* populate the airports table (courtesy [OurAirports](https://ourairports.com/))
+```
+# Local console
+% rake skyos:load_airports
+
+# On Docker host
+% docker-compose run --rm app rake skyos:load_airports
+```
+
+## Contributing
+
+### Development environment
 To get the Rails server running locally:
 
 * Clone this repo
@@ -28,112 +128,7 @@ To get the Rails server running locally:
    administrative user only.
 * `rails s` to start the local server
 
-### External Dependencies
-
-* [ImageMagick](https://imagemagick.org/)
-
-## Getting Started with Docker
-
-### Container Images
-
-#### From repository
-
-This repository builds and releases a Docker image to our GitHub Docker
-repository. See [docker-compose.yml.example](docker-compose.yml.example) for an
-example on how to pull the latest release and customize for your production 
-environment.
-
-#### Building your own image
-
-This repository comes equipped to be run within Docker. The easiest way to 
-build your own image is using [docker-compose](https://docs.docker.com/compose/). 
-
-Build the Docker image using:
-
-```
-% docker-compose build
-```
-
-### Configuration
-
-On first boot, the image will connect to the database specified in your 
-`docker-compose.yml` or to the PostgreSQL server specified via environment
-variables (see [docker-compose.yml.example](docker-compose.yml.example))
-
-Load defaults and create an initial administrative user:
-
-```
-% docker-compose run --rm app rake skyos:install
-```
-
-*Optionally* populate the airports table (courtesy [OurAirports](https://ourairports.com/))
-
-```
-% docker-compose run --rm app rake skyos:load_airports
-```
-
-After setting up, you can run the application and dependencies:
-
-```
-% docker-compose up -d
-```
-
-## Configuration
-
-### Environment Variables
-
-| Syntax                |             | Description                                                               |
-| :---                  |   :----:    | :-----------                                                              |
-| DATABASE_URL          |**required** | Database URL see [docker-compose.yml.example](docker-compose.yml.example) |
-| RAILS_HOSTNAME        |**required** | External hostname for application                                         |
-| REDIS_URL             |**required** | Redis URL see [docker-compose.yml.example](docker-compose.yml.example)    |
-| SECRET_KEY_BASE       |**required** | Key used to sign messages and encrypt cookies                             |
-| SMTP_SERVER           |**required** | Mail server, example: `smtp.example.com`                                  |
-| SMTP_PORT             | *optional*  | Mail server port, default: `25`                                           |
-| SMTP_DOMAIN           | *optional*  | Defaults to `RAILS_HOSTNAME`                                              |
-| SMTP_USERNAME         |**required** | Mail service username                                                     |
-| SMTP_PASSWORD         |**required** | Mail service password                                                     |
-| SMTP_AUTH             | *optional*  | Defaults to `plain`                                                       |
-
-### Rails Settings
-
-The `Setting` model contains settings that can be changed while the application
-is running. Administration of these settings can be performed live by visiting
-the `Admin -> Settings` page while logged in with an appropriate user account. 
-
-See `app\models\setting.rb` for defaults.
-
-### Initial administrator
-
-When users are registered, they automatically join the default Pilot user group.
-To create an initial administrative user run the following rake task:
-
-```
-rake skyos:create_admin
-```
-
-This will prompt you for the user attributes and assign the user administrative
-privileges.
-
-## Upgrading
-
-### Docker
-
-[docker-entrypoint.sh](/bin/docker-entrypoint.sh) runs at container start and 
-will automatically attempt to migrate and seed the database with changes as
-necessary.
-
-### Manual
-
-If the app is using a different environment then it may be necessary to run the 
-following steps after upgrade:
-
-```
-rake db:migrate
-rake db:seed
-```
-
-## Contributing
+### Basic workflow
 
 1. Fork it
 2. Create your feature branch (`git checkout -b my-new-feature`)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Clone the repository and build the Docker image using the included Dockerfile:
 
 One-click installation is available via the Deploy button above. For demo 
 purposes, free resources are selected. Production customization will 
-be necessary.
+be necessary. *For demo environments SMTP options can be left blank if you do 
+not wish to use functionality requiring email (registrations, contacts, etc).*
 
 See [Configuration](#configuration) for details on `Config Vars` 
 environment variables. The `DATABASE_URL` and `REDIS_URL` are automatically

--- a/app.json
+++ b/app.json
@@ -1,0 +1,76 @@
+{
+  "name": "skyOS",
+  "description": "A web-based virtual airline management system written in Rails",
+  "keywords": [
+    "rails",
+    "hobby-game",
+    "virtual-airlines-manager-system",
+    "virtual-airline"
+  ],
+  "repository": "https://github.com/lonestarvirtual/skyOS",
+  "env": {
+    "RAILS_HOSTNAME": {
+      "description": "Set the public hostname: app-name.herokuapp.com",
+      "value": ""
+    },
+    "RAILS_SERVE_STATIC_FILES": {
+      "description": "Have the application directly serve static assets",
+      "value": "enabled",
+      "required": false
+    },
+    "SECRET_KEY_BASE": {
+      "description": "A secret key for verifying the integrity of signed cookies.",
+      "generator": "secret"
+    },
+    "SMTP_SERVER": {
+      "description": "SMTP server hostname: smtp.server.com",
+      "value": "",
+      "required": false
+    },
+    "SMTP_PORT": {
+      "description": "SMTP server port",
+      "value": "587",
+      "required": false
+    },
+    "SMTP_USERNAME": {
+      "description": "SMTP username",
+      "value": "",
+      "required": false
+    },
+    "SMTP_PASSWORD": {
+      "description": "SMTP password",
+      "value": "",
+      "required": false
+    }
+  },
+  "addons": [
+    {
+      "plan": "heroku-postgresql:hobby-dev"
+    },
+    {
+      "plan": "rediscloud:30",
+      "as": "REDIS"
+    }
+  ],
+  "buildpacks": [
+    {
+      "url": "heroku/ruby"
+    },
+    {
+      "url": "https://github.com/DuckyTeam/heroku-buildpack-imagemagick"
+    }
+  ],
+  "formation": {
+    "web": {
+      "quantity": 1,
+      "size": "free"
+    },
+    "worker": {
+      "quantity": 1,
+      "size": "free"
+    }
+  },
+  "scripts": {
+    "postdeploy": "./bin/heroku-postdeploy.sh"
+  }
+}

--- a/bin/heroku-postdeploy.sh
+++ b/bin/heroku-postdeploy.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+echo "-- skyOS post deploy initialization --"
+
+echo "Creating and seeding the database"
+bundle exec rake db:prepare
+
+echo "Initializing default options"
+bundle exec rake skyos:init_defaults
+
+echo "Creating the default admin user"
+bundle exec rake skyos:create_admin[default]

--- a/lib/tasks/skyos/create_admin.rb
+++ b/lib/tasks/skyos/create_admin.rb
@@ -1,43 +1,58 @@
 # frozen_string_literal: true
 
+require 'optparse'
+
 namespace :skyos do
   desc 'Create an initial admin user'
-  task create_admin: :environment do
-    pilot = build_pilot
+  task :create_admin, [:default] => :environment do |_task, args|
+    options = args[:default].present? ? default_user : prompt_options
+    options.merge!({
+                     group: Group.find_by(name: 'Admin'),
+                     active: true,
+                     confirmed_at: Time.zone.now
+                   })
+
+    pilot = Pilot.new(options)
+
     # rubocop:disable Rails/Output
     if pilot.valid?
       pilot.save
       puts 'The user has been created'
     else
-      puts 'The user is not valid'
+      puts 'ERROR - admin user is not valid:'
+      pilot.errors.full_messages.each do |message|
+        puts message
+      end
     end
     # rubocop:enable Rails/Output
   end
 
-  # rubocop:disable Metrics/AbcSize
-  # rubocop:disable Metrics/MethodLength
-  # rubocop:disable Rails/Output
-  def build_pilot
-    print 'First name: '
-    first_name = STDIN.gets.chomp
-    print 'Last name: '
-    last_name = STDIN.gets.chomp
-    print 'email: '
-    email = STDIN.gets.chomp
-    print 'Password: '
-    password = STDIN.noecho(&:gets).chomp
-    puts
-    Pilot.new(
-      first_name: first_name,
-      last_name: last_name,
-      email: email,
-      password: password,
-      group: Group.find_by(name: 'Admin'),
-      active: true,
-      confirmed_at: Time.zone.now
-    )
+  def default_user
+    {
+      first_name: 'Default',
+      last_name: 'Admin',
+      email: 'admin@example.com',
+      password: 'password'
+    }
   end
-  # rubocop:enable Metrics/AbcSize
-  # rubocop:enable Metrics/MethodLength
+
+  # rubocop:disable Rails/Output
+  # rubocop:disable Metrics/MethodLength
+  def prompt_options
+    options = {}
+
+    print 'First name: '
+    options[:first_name] = STDIN.gets.chomp
+    print 'Last name: '
+    options[:last_name] = STDIN.gets.chomp
+    print 'email: '
+    options[:email] = STDIN.gets.chomp
+    print 'Password: '
+    options[:password] = STDIN.noecho(&:gets).chomp
+    puts
+
+    options
+  end
   # rubocop:enable Rails/Output
+  # rubocop:enable Metrics/MethodLength
 end


### PR DESCRIPTION
This PR adds `app.json` to allow for easy one-click installations on Heroku. `README.md` has also been significantly overhauled in order to prepare for more general use. 

Additionally the Rake task `skyos:create_admin` has been cleaned up and additionally allows an argument to create a default user for automated deployment scenarios.

### Further Work
Additional work is still required to generalize branding and allow it to be configurable within the web interface.