### PR TITLE
Fix deprecated set-env command in GH actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Get release version
         id: get_version
-        run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Publish to GitHub Registry
         uses: elgohr/Publish-Docker-Github-Action@master


### PR DESCRIPTION
Fixed deprecated GitHub action command [`set-env`](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) previously used in publish workflow to obtain the release version.
